### PR TITLE
Disallow travis to send emails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 
 notifications:
   slack: jfixtures:jOwrd0VAUWmsEqAMtfwqOM9J
+  email: false
 
 env:
   global:


### PR DESCRIPTION
Given that the build result goes to slack and visible in PRs