### PR TITLE
SQL blocks now can have commas

### DIFF
--- a/src/main/java/com/github/vkorobkov/jfixtures/config/structure/tables/Tables.java
+++ b/src/main/java/com/github/vkorobkov/jfixtures/config/structure/tables/Tables.java
@@ -1,7 +1,6 @@
 package com.github.vkorobkov.jfixtures.config.structure.tables;
 
 import com.github.vkorobkov.jfixtures.config.structure.Section;
-import com.github.vkorobkov.jfixtures.config.structure.util.SplitStringConsumer;
 import com.github.vkorobkov.jfixtures.config.structure.util.TableMatcher;
 import com.github.vkorobkov.jfixtures.config.yaml.Node;
 import com.github.vkorobkov.jfixtures.util.CollectionUtil;
@@ -53,8 +52,10 @@ public class Tables extends Section {
 
     private List<String> readArrayRecursively(String... sections) {
         List<String> instructions = new ArrayList<>();
-        CollectionUtil.flattenRecursively(readProperty(sections).orElse(Collections.emptyList()),
-                new SplitStringConsumer(instructions::add));
+        CollectionUtil.flattenRecursively(
+            readProperty(sections).orElse(Collections.emptyList()),
+            element -> instructions.add(String.valueOf(element))
+        );
         return instructions;
     }
 

--- a/src/test/groovy/com/github/vkorobkov/jfixtures/config/structure/tables/TablesTest.groovy
+++ b/src/test/groovy/com/github/vkorobkov/jfixtures/config/structure/tables/TablesTest.groovy
@@ -156,6 +156,19 @@ class TablesTest extends Specification {
         getBeforeInserts(BEFORE_INSERTS_CONFIG, "mates") == ["// Doing table \$TABLE_NAME", "BEGIN TRANSACTION;"]
     }
 
+    def "#getBeforeInserts allows commas in SQL statements"() {
+        given:
+        def config = [
+            transactional_users  : [
+                applies_to    : "users",
+                before_inserts: "INSERT INTO LOG(time, event) VALUES (NOW(), 'before_table');"
+            ]
+        ]
+
+        expect:
+        getBeforeInserts(config, "users") == ["INSERT INTO LOG(time, event) VALUES (NOW(), 'before_table');"]
+    }
+
     def "getAfterInserts returns 'empty value' by default"() {
         expect:
         getAfterInserts(SAMPLE_CONFIG, "users") == []
@@ -168,6 +181,19 @@ class TablesTest extends Specification {
         getAfterInserts(AFTER_INSERTS_CONFIG, "mates") == ["// Completed table \$TABLE_NAME", "COMMIT TRANSACTION;"]
     }
 
+    def "#getAfterInserts allows commas in SQL statements"() {
+        given:
+        def config = [
+            transactional_users  : [
+                applies_to    : "users",
+                after_inserts: "INSERT INTO LOG(time, event) VALUES (NOW(), 'before_table');"
+            ]
+        ]
+
+        expect:
+        getAfterInserts(config, "users") == ["INSERT INTO LOG(time, event) VALUES (NOW(), 'before_table');"]
+    }
+
     def "getBeforeCleanup returns 'empty value' by default"() {
         expect:
         getBeforeCleanup(SAMPLE_CONFIG, "users") == []
@@ -178,6 +204,19 @@ class TablesTest extends Specification {
         getBeforeCleanup(BEFORE_CLEANUP_CONFIG, "users") == ["BEGIN TRANSACTION;"]
         getBeforeCleanup(BEFORE_CLEANUP_CONFIG, "friends") == ["// Beginning of the table \$TABLE_NAME", "BEGIN TRANSACTION;"]
         getBeforeCleanup(BEFORE_CLEANUP_CONFIG, "mates") == ["// Beginning of the table \$TABLE_NAME", "BEGIN TRANSACTION;"]
+    }
+
+    def "#getBeforeCleanup allows commas in SQL statements"() {
+        given:
+        def config = [
+            transactional_users  : [
+                applies_to    : "users",
+                before_cleanup: "INSERT INTO LOG(time, event) VALUES (NOW(), 'before_table');"
+            ]
+        ]
+
+        expect:
+        getBeforeCleanup(config, "users") == ["INSERT INTO LOG(time, event) VALUES (NOW(), 'before_table');"]
     }
 
     def "#getDefaultColumns returns empty map if tables is not matched by the rule"() {

--- a/src/test/resources/checkstyle.xml
+++ b/src/test/resources/checkstyle.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module SYSTEM "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
 
 <module name="Checker">
     <property name="fileExtensions" value="java, properties, xml"/>


### PR DESCRIPTION
SQL blocks now can have commas.

Before the fix every comma initiated a new SQL statement in a new line:
![2018-02-15_20-28-22](https://user-images.githubusercontent.com/12804703/36275854-1c140f4a-129d-11e8-87ca-0b67ce042d56.png)
