### PR TITLE
Concatenate SQL insertions across applied table rules

### DIFF
--- a/src/main/java/com/github/vkorobkov/jfixtures/config/structure/tables/Tables.java
+++ b/src/main/java/com/github/vkorobkov/jfixtures/config/structure/tables/Tables.java
@@ -34,15 +34,15 @@ public class Tables extends Section {
     }
 
     public List<String> getBeforeInserts() {
-        return readArrayRecursively("before_inserts");
+        return readArray("before_inserts");
     }
 
     public List<String> getBeforeCleanup() {
-        return readArrayRecursively("before_cleanup");
+        return readArray("before_cleanup");
     }
 
     public List<String> getAfterInserts() {
-        return readArrayRecursively("after_inserts");
+        return readArray("after_inserts");
     }
 
     public Map<String, Object> getDefaultColumns() {
@@ -50,25 +50,25 @@ public class Tables extends Section {
                 MapMerger::merge, "default_columns").orElse(Collections.emptyMap());
     }
 
-    private List<String> readArrayRecursively(String... sections) {
-        List<String> instructions = new ArrayList<>();
-        CollectionUtil.flattenRecursively(
-            readProperty(sections).orElse(Collections.emptyList()),
-            element -> instructions.add(String.valueOf(element))
-        );
-        return instructions;
+    private List readArray(String... sections) {
+        List result = new ArrayList();
+        readSections(sections).forEach(elem -> CollectionUtil.flattenRecursively(elem, result::add));
+        return result;
     }
 
-    private <T> Optional<T> readProperty(String ... sections) {
+    private <T> Optional<T> readProperty(String... sections) {
         return readProperty((current, last) -> last, sections);
     }
 
     private <T> Optional<T> readProperty(BinaryOperator<T> reducer, String... sections) {
+        return this.<T>readSections(sections).reduce(reducer);
+    }
+
+    private <T> Stream<T> readSections(String... sections) {
         return this.<T>getMatchingTables()
-                .map(node -> node.dig(sections).<T>optional())
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .reduce(reducer);
+            .map(node -> node.dig(sections).<T>optional())
+            .filter(Optional::isPresent)
+            .map(Optional::get);
     }
 
     private Stream<Node> getMatchingTables() {

--- a/src/test/groovy/com/github/vkorobkov/jfixtures/config/structure/tables/TablesTest.groovy
+++ b/src/test/groovy/com/github/vkorobkov/jfixtures/config/structure/tables/TablesTest.groovy
@@ -169,6 +169,27 @@ class TablesTest extends Specification {
         getBeforeInserts(config, "users") == ["INSERT INTO LOG(time, event) VALUES (NOW(), 'before_table');"]
     }
 
+    def "#getBeforeInserts concatenates sql fragments across applied rules"() {
+        given:
+        def config = [
+            comment_on_users  : [
+                applies_to    : "users",
+                before_inserts: "-- Starting a new table"
+            ],
+            transactional_users: [
+                applies_to    : "users",
+                before_inserts: ["-- Starting transaction", "BEGIN TRANSACTION"]
+            ]
+        ]
+
+        expect:
+        getBeforeInserts(config, "users") == [
+            "-- Starting a new table",
+            "-- Starting transaction",
+            "BEGIN TRANSACTION"
+        ]
+    }
+
     def "getAfterInserts returns 'empty value' by default"() {
         expect:
         getAfterInserts(SAMPLE_CONFIG, "users") == []
@@ -194,6 +215,27 @@ class TablesTest extends Specification {
         getAfterInserts(config, "users") == ["INSERT INTO LOG(time, event) VALUES (NOW(), 'before_table');"]
     }
 
+    def "#getAfterInserts concatenates sql fragments across applied rules"() {
+        given:
+        def config = [
+            comment_on_users  : [
+                applies_to    : "users",
+                after_inserts: "-- Table is done"
+            ],
+            transactional_users: [
+                applies_to    : "users",
+                after_inserts: ["-- Committing transaction", "COMMIT TRANSACTION"]
+            ]
+        ]
+
+        expect:
+        getAfterInserts(config, "users") == [
+            "-- Table is done",
+            "-- Committing transaction",
+            "COMMIT TRANSACTION"
+        ]
+    }
+
     def "getBeforeCleanup returns 'empty value' by default"() {
         expect:
         getBeforeCleanup(SAMPLE_CONFIG, "users") == []
@@ -217,6 +259,27 @@ class TablesTest extends Specification {
 
         expect:
         getBeforeCleanup(config, "users") == ["INSERT INTO LOG(time, event) VALUES (NOW(), 'before_table');"]
+    }
+
+    def "#getBeforeCleanup concatenates sql fragments across applied rules"() {
+        given:
+        def config = [
+            comment_on_users  : [
+                applies_to    : "users",
+                before_cleanup: "-- Starting a new table"
+            ],
+            transactional_users: [
+                applies_to    : "users",
+                before_cleanup: ["-- Starting transaction", "BEGIN TRANSACTION"]
+            ]
+        ]
+
+        expect:
+        getBeforeCleanup(config, "users") == [
+            "-- Starting a new table",
+            "-- Starting transaction",
+            "BEGIN TRANSACTION"
+        ]
     }
 
     def "#getDefaultColumns returns empty map if tables is not matched by the rule"() {


### PR DESCRIPTION
Concatenate SQL insertions across applied table rules, so the SQL statements from shared rules can be reused/merged with more specific ones.