### PR TITLE
Allowing SqlResult to consume any SQL implementation

### DIFF
--- a/src/main/java/com/github/vkorobkov/jfixtures/result/SqlResult.java
+++ b/src/main/java/com/github/vkorobkov/jfixtures/result/SqlResult.java
@@ -2,8 +2,8 @@ package com.github.vkorobkov.jfixtures.result;
 
 import com.github.vkorobkov.jfixtures.instructions.Instruction;
 import com.github.vkorobkov.jfixtures.sql.Appender;
+import com.github.vkorobkov.jfixtures.sql.Sql;
 import com.github.vkorobkov.jfixtures.sql.SqlBridge;
-import com.github.vkorobkov.jfixtures.sql.SqlType;
 import com.github.vkorobkov.jfixtures.sql.appenders.FileAppender;
 import com.github.vkorobkov.jfixtures.sql.appenders.StringAppender;
 import com.github.vkorobkov.jfixtures.util.WithResource;
@@ -17,11 +17,11 @@ import static java.util.Collections.unmodifiableCollection;
 @Getter
 public class SqlResult implements StringResult {
     private final Collection<Instruction> instructions;
-    private final SqlType type;
+    private final Sql sql;
 
-    public SqlResult(Collection<Instruction> instructions, SqlType type) {
+    public SqlResult(Collection<Instruction> instructions, Sql sql) {
         this.instructions = unmodifiableCollection(instructions);
-        this.type = type;
+        this.sql = sql;
     }
 
     @Override
@@ -40,6 +40,6 @@ public class SqlResult implements StringResult {
     }
 
     private <T extends Appender> SqlBridge createSqlBridge(T appender) {
-        return new SqlBridge(type.getSqlDialect(), appender);
+        return new SqlBridge(sql, appender);
     }
 }

--- a/src/test/groovy/com/github/vkorobkov/jfixtures/result/SqlResultTest.groovy
+++ b/src/test/groovy/com/github/vkorobkov/jfixtures/result/SqlResultTest.groovy
@@ -25,18 +25,18 @@ class SqlResultTest extends Specification implements Assertions {
     ]
 
     @Shared
-    def subject = new SqlResult(instructions, SqlType.SQL99)
+    def subject = new SqlResult(instructions, SqlType.SQL99.sqlDialect)
 
     def EXPECTED_SQL = """DELETE FROM "users";
             |INSERT INTO "users" ("id", "name", "age") VALUES (1, 'Vlad', 30);
             |""".stripMargin()
 
-    def "::constructor saves instructions and sql type"() {
+    def "::constructor saves instructions and sql implementation"() {
         expect:
         assertCollectionsEqual(subject.instructions, instructions)
 
         and:
-        subject.type == SqlType.SQL99
+        subject.sql == SqlType.SQL99.sqlDialect
     }
 
     def "::constructor saves instructions as unmodifiable collection"() {


### PR DESCRIPTION
Amendment for #182: instead of passing `SqlType` enum which consists of hardcoded SQL dialect, it is much more flexible to allow to pass any `Sql` implementation so for API user it is much easier to create a new SQL(or non SQL) dialect